### PR TITLE
fix build problems on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,22 @@
 sudo: false
+
 language: node_js
+
 node_js:
   - '4'
   - '5'
   - stable
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+
+env:
+  global:
+    - CXX=g++-4.8
 
 script:
   - npm run lint

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lru-cache": "^2.5.0",
     "registry-static": "github:diasdavid/registry-static",
     "ronin": "^0.3.11",
-    "st": "^1.0.0"
+    "st": "^1.0.0",
+    "ipfs-api": "github:ipfs/js-ipfs-api#ba85b3b"
   },
   "devDependencies": {
     "eslint-config-standard-react": "^1.2.1",


### PR DESCRIPTION
~~Still not working with node4, see~~

~~https://travis-ci.org/ralphtheninja/registry-mirror/jobs/93163938~~

~~I suspect this has to do with the fact that npm3 flattens node_modules folder, thus making [this](https://github.com/diasdavid/registry-mirror/blob/7747e72f58693747989b1c882b482c8a0a5438a3/src/fetch-ipns.js#L2) work, if npm@2 is used it doesn't~~