### PR TITLE
import debugger as log.err

### DIFF
--- a/src/registry-cache.js
+++ b/src/registry-cache.js
@@ -1,7 +1,7 @@
 const debug = require('debug')
 const log = debug('registry-mirror')
 const async = require('async')
-log.error = debug('registry-mirror:error')
+log.err = debug('registry-mirror:error')
 const config = require('./config')
 const api = config.apiCtl
 


### PR DESCRIPTION
I was getting the below error so i updated the import constant name.

```
> registry-mirror npm publish
TypeError: log.err is not a function
    at /home/XX/.nvm/versions/node/v4.2.2/lib/node_modules/registry-mirror/src/registry-cache.js:46:18
        at /home/XX/.nvm/versions/node/v4.2.2/lib/node_modules/registry-mirror/node_modules/ipfs-api/src/request-api.js:41:9
            at finish (/home/XX/.nvm/versions/node/v4.2.2/lib/node_modules/registry-mirror/node_modules/wreck/lib/index.js:330:16)
        at wrapped (/home/XX/.nvm/versions/node/v4.2.2/lib/node_modules/registry-mirror/node_modules/wreck/node_modules/hoek/lib/index.js:867:20)
        at onReaderFinish (/home/XX/.nvm/versions/node/v4.2.2/lib/node_modules/registry-mirror/node_modules/wreck/lib/index.js:376:16)                                    
        at g (events.js:260:16)
        at emitNone (events.js:72:20)
        at emit (events.js:166:7)
        at finishMaybe (_stream_writable.js:468:14)
        at afterWrite (_stream_writable.js:347:3)
```